### PR TITLE
feat: add pagination to Catalog page

### DIFF
--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -28,7 +28,13 @@ function ProductCard({ product }: ProductCardProps) {
     <Box className={styles.container} onClick={handleClick}>
       <Paper elevation={3} className={styles.card}>
         <Box className={styles.content}>
-          <Box component="img" className={styles.image} alt="Plant" src={product.images?.[0].url || Placeholder} />
+          <Box
+            component="img"
+            className={styles.image}
+            alt="Plant"
+            src={product.images?.[0]?.url || Placeholder}
+            loading="lazy"
+          />
           <Box className={styles.description}>
             <Typography gutterBottom variant="h5" component="div" mt={1}>
               {product.name}

--- a/src/components/ProductCard/__snapshots__/ProductCard.test.tsx.snap
+++ b/src/components/ProductCard/__snapshots__/ProductCard.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`Main component rendering performs snapshot testing 1`] = `
             <img
               alt="Plant"
               class="MuiBox-root css-0"
+              loading="lazy"
               src="image.png"
             />
             <div
@@ -61,6 +62,7 @@ exports[`Main component rendering performs snapshot testing 1`] = `
           <img
             alt="Plant"
             class="MuiBox-root css-0"
+            loading="lazy"
             src="image.png"
           />
           <div

--- a/src/components/catalog/CategoriesTree/CategoriesTree.tsx
+++ b/src/components/catalog/CategoriesTree/CategoriesTree.tsx
@@ -43,6 +43,8 @@ const CategoriesTree: FC<CategoriesTreeProps> = ({ setActiveCategory, activeCate
 
     const newSearchParams = new URLSearchParams(location.search);
     newSearchParams.set(FilterNames.CATEGORY_ID, category.id);
+    newSearchParams.set(FilterNames.PAGE, '1');
+
     submit(newSearchParams);
   };
 

--- a/src/components/catalog/FiltersForm/FiltersForm.tsx
+++ b/src/components/catalog/FiltersForm/FiltersForm.tsx
@@ -44,6 +44,8 @@ const FiltersForm = ({ filtersValuesUrl }: { filtersValuesUrl: FilterData }) => 
     newSearchParams.set(FilterNames.COLOR, colorValue);
     if (priceValue) newSearchParams.set(FilterNames.PRICE, priceValue);
 
+    newSearchParams.set(FilterNames.PAGE, '1');
+
     submit(newSearchParams);
   };
 
@@ -53,6 +55,8 @@ const FiltersForm = ({ filtersValuesUrl }: { filtersValuesUrl: FilterData }) => 
     newSearchParams.delete(FilterNames.SIZE);
     newSearchParams.delete(FilterNames.COLOR);
     newSearchParams.delete(FilterNames.PRICE);
+
+    newSearchParams.set(FilterNames.PAGE, '1');
 
     submit(newSearchParams);
   };

--- a/src/components/catalog/SortForm/SortForm.tsx
+++ b/src/components/catalog/SortForm/SortForm.tsx
@@ -25,6 +25,8 @@ const SortForm: React.FC<FormSelectProps> = ({ label, name, options }) => {
     const newSearchParams = new URLSearchParams(location.search);
     newSearchParams.set(FilterNames.SORT, sortValue);
 
+    newSearchParams.set(FilterNames.PAGE, '1');
+
     submit(newSearchParams);
   };
 

--- a/src/pages/Catalog/Catalog.tsx
+++ b/src/pages/Catalog/Catalog.tsx
@@ -1,18 +1,29 @@
 import { catalogService } from '@/services/catalogService';
 import { SyntheticEvent, useEffect, useState } from 'react';
 import Grid from '@mui/material/Unstable_Grid2';
-import { Typography, Box, Button, Drawer, Divider, Breadcrumbs, Link } from '@mui/material';
+import {
+  Typography,
+  Box,
+  Button,
+  Drawer,
+  Divider,
+  Breadcrumbs,
+  Link,
+  Pagination,
+  PaginationItem,
+  CircularProgress,
+} from '@mui/material';
 import ProductCard from '@/components/ProductCard/ProductCard';
 import { Category, FetchProductsResponse } from '@/types';
 import { ButtonLabels, CategoryAllNode, FilterNames, PageData, SortOptions, scrollbarStyles } from './constants';
-import { useLoaderData, useSubmit } from 'react-router-dom';
+import { useLoaderData, useLocation, useSubmit, Link as PageLink } from 'react-router-dom';
 import CategoriesTree from '@/components/catalog/CategoriesTree/CategoriesTree';
 import SearchForm from '@/components/catalog/SearchForm/SearchForm';
 import SortForm from '@/components/catalog/SortForm/SortForm';
 import FiltersForm from '@/components/catalog/FiltersForm/FiltersForm';
 
 export function Catalog() {
-  const { products, queryParams } = useLoaderData() as FetchProductsResponse;
+  const { products, pagination, queryParams } = useLoaderData() as FetchProductsResponse;
 
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
   const [breadcrumbs, setBreadcrumbs] = useState<Category[]>([CategoryAllNode]);
@@ -21,6 +32,10 @@ export function Catalog() {
   const [isClosing, setIsClosing] = useState(false);
 
   const submit = useSubmit();
+  const location = useLocation();
+  const query = new URLSearchParams(location.search);
+
+  const page = parseInt(query.get('page') || '1', 10);
 
   const fetchBreadcrumbs = async (categoryId: string | null) => {
     if (!categoryId) {
@@ -80,9 +95,10 @@ export function Catalog() {
     e.preventDefault();
     setActiveCategory(category.id);
 
-    const newSearchParams = new URLSearchParams(location.search);
-    newSearchParams.set(FilterNames.CATEGORY_ID, category.id);
-    submit(newSearchParams);
+    query.set(FilterNames.CATEGORY_ID, category.id);
+    query.set(FilterNames.PAGE, '1');
+
+    submit(query);
   };
 
   const drawer = (
@@ -158,43 +174,69 @@ export function Catalog() {
       </Drawer>
 
       <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
-        <Grid container xs={12} sx={{ mb: 2 }}>
-          <Grid>
-            {breadcrumbs.length > 0 && (
-              <Breadcrumbs aria-label="breadcrumb">
-                {breadcrumbs.map((category, index) => (
-                  <Link
-                    key={category.id}
-                    underline="hover"
-                    color={index === breadcrumbs.length - 1 ? 'text.primary' : 'inherit'}
-                    href={`/catalog?filter=${category.id}`}
-                    onClick={handleBreadcrumbClick(category)}
-                  >
-                    {category.name}
-                  </Link>
-                ))}
-              </Breadcrumbs>
-            )}
-          </Grid>
-        </Grid>
-        <Grid container justifyContent="space-between" sx={{ mb: 3 }}>
-          <Grid>
-            <Button variant="text" color="primary" onClick={handleDrawerToggle} sx={{ mr: 2, display: { sm: 'none' } }}>
-              {ButtonLabels.OPEN}
-            </Button>
-          </Grid>
-          <Grid display="flex">
-            <SearchForm value={queryParams.search} />
-          </Grid>
-        </Grid>
-        <Grid container spacing={{ xs: 2, md: 3 }} columns={{ xs: 4, sm: 8, md: 12 }}>
-          {!products.length && <Typography>{PageData.NO_PRODUCTS}</Typography>}
-          {products.map((product) => (
-            <Grid xs={4} sm={4} md={4} key={product.id}>
-              <ProductCard product={product} />
+        {catalogService.loading === true ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <>
+            <Grid container xs={12} sx={{ mb: 2 }}>
+              <Grid>
+                {breadcrumbs.length > 0 && (
+                  <Breadcrumbs aria-label="breadcrumb">
+                    {breadcrumbs.map((category, index) => (
+                      <Link
+                        key={category.id}
+                        underline="hover"
+                        color={index === breadcrumbs.length - 1 ? 'text.primary' : 'inherit'}
+                        href={`/catalog?filter=${category.id}`}
+                        onClick={handleBreadcrumbClick(category)}
+                      >
+                        {category.name}
+                      </Link>
+                    ))}
+                  </Breadcrumbs>
+                )}
+              </Grid>
             </Grid>
-          ))}
-        </Grid>
+            <Grid container justifyContent="space-between" sx={{ mb: 3 }}>
+              <Grid>
+                <Button
+                  variant="text"
+                  color="primary"
+                  onClick={handleDrawerToggle}
+                  sx={{ mr: 2, display: { sm: 'none' } }}
+                >
+                  {ButtonLabels.OPEN}
+                </Button>
+              </Grid>
+              <Grid display="flex">
+                <SearchForm value={queryParams.search} />
+              </Grid>
+            </Grid>
+            <Grid container spacing={{ xs: 2, md: 3 }} columns={{ xs: 4, sm: 8, md: 12 }}>
+              {!products.length && <Typography>{PageData.NO_PRODUCTS}</Typography>}
+              {products.map((product) => (
+                <Grid xs={4} sm={4} md={4} key={product.id}>
+                  <ProductCard product={product} />
+                </Grid>
+              ))}
+            </Grid>
+            {!!products.length && (
+              <Grid sx={{ mt: 4 }}>
+                <Pagination
+                  page={page}
+                  count={pagination.pageAmount}
+                  renderItem={(item) => {
+                    const newQuery = new URLSearchParams(query.toString());
+                    newQuery.set('page', item.page?.toString() || '1');
+                    return <PaginationItem component={PageLink} to={`?${newQuery.toString()}`} {...item} />;
+                  }}
+                />
+              </Grid>
+            )}
+          </>
+        )}
       </Box>
     </Box>
   );

--- a/src/pages/Catalog/constants.ts
+++ b/src/pages/Catalog/constants.ts
@@ -24,6 +24,7 @@ export enum FilterNames {
   SIZE = 'size',
   COLOR = 'color',
   PRICE = 'price',
+  PAGE = 'page',
 }
 
 export const SortOptions: FilterAttributes[] = [

--- a/src/pages/Main/__snapshots__/Main.test.tsx.snap
+++ b/src/pages/Main/__snapshots__/Main.test.tsx.snap
@@ -48,6 +48,7 @@ exports[`Main component rendering performs snapshot testing 1`] = `
                     <img
                       alt="Plant"
                       class="MuiBox-root css-0"
+                      loading="lazy"
                       src="image.png"
                     />
                     <div
@@ -175,6 +176,7 @@ exports[`Main component rendering performs snapshot testing 1`] = `
                           <img
                             alt="Plant"
                             class="MuiBox-root css-0"
+                            loading="lazy"
                             src="image2.png"
                           />
                           <div
@@ -257,6 +259,7 @@ exports[`Main component rendering performs snapshot testing 1`] = `
                   <img
                     alt="Plant"
                     class="MuiBox-root css-0"
+                    loading="lazy"
                     src="image.png"
                   />
                   <div
@@ -384,6 +387,7 @@ exports[`Main component rendering performs snapshot testing 1`] = `
                         <img
                           alt="Plant"
                           class="MuiBox-root css-0"
+                          loading="lazy"
                           src="image2.png"
                         />
                         <div

--- a/src/services/constants.ts
+++ b/src/services/constants.ts
@@ -5,4 +5,8 @@ const sortMapping: Record<string, string> = {
   'name-desc': 'name.en-GB desc',
 };
 
+export const enum pageLimit {
+  productAmount = 6,
+}
+
 export default sortMapping;

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,9 @@ export interface FetchProductsRequest {
 
 export interface FetchProductsResponse {
   products: Product[];
+  pagination: {
+    pageAmount: number;
+  };
   queryParams: {
     filters: FilterData;
     search: string;


### PR DESCRIPTION
### **Link to issue:** [link](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint4/RSS-ECOMM-4_03.md)

### **Overview:**
  + implement a technique such as lazy loading images and pagination on the Catalog page.

### **Features implemented:**
  - Products are loaded 6 items per page.
  - Spinner for loading state is displayed.

### **Technical details:**
 n/a

### **Screenshots:*

![chrome_3D292wRYLi](https://github.com/frrrolova/e-commerce/assets/17529377/db921eac-aacc-4969-97d7-cf3d81e05269)
*

