### PR TITLE
fix: correct infocard layout for small screen

### DIFF
--- a/src/components/InfoCard/InfoCard.module.scss
+++ b/src/components/InfoCard/InfoCard.module.scss
@@ -34,12 +34,14 @@
       padding-right: 2rem;
 
       &.imageRight {
-        flex-direction: row-reverse;
+        @media (min-width: 600px) {
+          flex-direction: row-reverse;
+        }
       }
 
       p {
         margin-top: 2rem;
-        @media (max-width: 599px) {
+        @media (max-width: 599.9px) {
           margin-top: 1rem;
         }
       }
@@ -54,7 +56,7 @@
     .image {
       height: $height-promo-image;
       filter: drop-shadow(5px 10px 15px $shadow-color);
-      @media (max-width: 599px) {
+      @media (max-width: 599.9px) {
         height: $height-promo-image-xs;
       }
       @media (min-width: 600px) {


### PR DESCRIPTION
### **Overview:**
 +  fix InfoCard layout for small screen on Main page ('Promotions' section)

### **Screenshots:**  
![chrome_SPpTor2umy](https://github.com/frrrolova/e-commerce/assets/17529377/5d1e3dd3-1d8f-441f-9f11-0b6a2247a158)
