### PR TITLE
fix: set active values in filters selects

### DIFF
--- a/src/components/catalog/CategoriesTree/CategoriesTree.tsx
+++ b/src/components/catalog/CategoriesTree/CategoriesTree.tsx
@@ -64,7 +64,7 @@ const CategoriesTree: FC<CategoriesTreeProps> = ({ setActiveCategory, activeCate
           },
         }),
         ...(activeCategory !== nodes.id && {
-          [`& .MuiTreeItem-content:not(.Mui-selected)`]: {
+          [`& .MuiTreeItem-content`]: {
             backgroundColor: 'transparent!important',
           },
         }),

--- a/src/components/catalog/FiltersForm/FiltersForm.tsx
+++ b/src/components/catalog/FiltersForm/FiltersForm.tsx
@@ -6,18 +6,20 @@ import { FilterNames, PageData, allOption } from '@/pages/Catalog/constants';
 import FormSelect from '@/components/FormSelect/FormSelect';
 import { catalogService } from '@/services/catalogService';
 import { FormEvent, useEffect, useState } from 'react';
-import { FetchProductsResponse, Filter, FilterData } from '@/types';
+import { FetchProductsResponse, Filter } from '@/types';
 
-const FiltersForm = ({ filtersValuesUrl }: { filtersValuesUrl: FilterData }) => {
+const FiltersForm = () => {
   const { queryParams } = useLoaderData() as FetchProductsResponse;
   const [filtersData, setFiltersData] = useState<Filter[] | null>(null);
-  const [selectedSize, setSelectedSize] = useState<string>(queryParams.filters.size || allOption.TITLE);
-  const [selectedColor, setSelectedColor] = useState<string>(queryParams.filters.color || allOption.TITLE);
-  const [selectedPriceRange, setSelectedPriceRange] = useState<number[]>(filtersValuesUrl.price || defaultPriceRange);
+  const [selectedFilters, setSelectedFilters] = useState({
+    size: queryParams.filters.size || allOption.TITLE,
+    color: queryParams.filters.color || allOption.TITLE,
+    price: queryParams.filters.price || defaultPriceRange,
+  });
 
   const submit = useSubmit();
 
-  const loadFilters = async () => {
+  const fetchFilters = async () => {
     try {
       const resp = await catalogService.fetchFilterAttributes();
       setFiltersData(resp);
@@ -27,8 +29,23 @@ const FiltersForm = ({ filtersValuesUrl }: { filtersValuesUrl: FilterData }) => 
   };
 
   useEffect(() => {
-    loadFilters();
+    fetchFilters();
   }, []);
+
+  useEffect(() => {
+    setSelectedFilters({
+      size: queryParams.filters.size || allOption.TITLE,
+      color: queryParams.filters.color || allOption.TITLE,
+      price: queryParams.filters.price || defaultPriceRange,
+    });
+  }, [queryParams]);
+
+  const handleFilterChange = (name: string, value: string | number | number[]) => {
+    setSelectedFilters((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
 
   const applyFilters = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -60,23 +77,12 @@ const FiltersForm = ({ filtersValuesUrl }: { filtersValuesUrl: FilterData }) => 
     submit(newSearchParams);
   };
 
-  const handleSizeChange = (event: SelectChangeEvent) => {
-    setSelectedSize(event.target.value as string);
+  const mapOptions = (index: number) => {
+    if (filtersData) {
+      return filtersData[index]?.options.map((item) => ({ key: item.key, label: item.label }));
+    }
+    return [];
   };
-
-  const handleColorChange = (event: SelectChangeEvent) => {
-    setSelectedColor(event.target.value as string);
-  };
-
-  const handlePriceRangeChange = (_event: Event, newValue: number | number[]) => {
-    setSelectedPriceRange(newValue as number[]);
-  };
-
-  useEffect(() => {
-    setSelectedSize(queryParams.filters.size || allOption.TITLE);
-    setSelectedColor(queryParams.filters.color || allOption.TITLE);
-    setSelectedPriceRange(filtersValuesUrl.price);
-  }, [filtersValuesUrl.size, filtersValuesUrl.color, filtersValuesUrl.price, queryParams]);
 
   return (
     <Form
@@ -93,24 +99,24 @@ const FiltersForm = ({ filtersValuesUrl }: { filtersValuesUrl: FilterData }) => 
           <FormSelect
             label={filtersData[0].label}
             name={filtersData[0].name}
-            options={filtersData[0]?.options.map((item) => ({ key: item.key, label: item.label }))}
-            value={selectedSize}
-            onChange={handleSizeChange}
+            options={mapOptions(0)}
+            value={selectedFilters.color}
+            onChange={(e: SelectChangeEvent) => handleFilterChange(FilterNames.COLOR, e.target.value)}
           />
           <FormSelect
             label={filtersData[1].label}
             name={filtersData[1].name}
-            options={filtersData[1]?.options.map((item) => ({ key: item.key, label: item.label }))}
-            value={selectedColor}
-            onChange={handleColorChange}
+            options={mapOptions(1)}
+            value={selectedFilters.size}
+            onChange={(e: SelectChangeEvent) => handleFilterChange(FilterNames.SIZE, e.target.value)}
           />
           <Box className={styles.priceBox}>
             <Typography variant="body2">{PageData.PRICE_RANGE}</Typography>
             <Slider
               id={FilterNames.PRICE}
               name={FilterNames.PRICE}
-              value={selectedPriceRange}
-              onChange={handlePriceRangeChange}
+              value={selectedFilters.price}
+              onChange={(_, value) => handleFilterChange(FilterNames.PRICE, value as number[])}
               valueLabelDisplay="auto"
               min={defaultPriceRange[0]}
               max={defaultPriceRange[1]}

--- a/src/pages/Catalog/Catalog.tsx
+++ b/src/pages/Catalog/Catalog.tsx
@@ -111,7 +111,7 @@ export function Catalog() {
       <Divider sx={{ mt: 2, mb: 2 }} />
 
       {/* Filters */}
-      <FiltersForm filtersValuesUrl={queryParams.filters} />
+      <FiltersForm />
     </Box>
   );
 


### PR DESCRIPTION
### **Details:**
  - On Catalog page: set filters, click the 'Apply filters' button.  
  Result: Filters selects should have applied values.  
  - Selects should save values ​​after refreshing the page.  
  - Fix: set transparent background for the previous active category when searching for a product.

### **Screenshots:**  
 
![chrome_jJ02yuVxwz](https://github.com/user-attachments/assets/09dc213b-5e39-46ee-bf3f-44fc7cde9319)